### PR TITLE
feat(#494): shared framework-agnostic CIP-30 wallet connector

### DIFF
--- a/src/helpers/walletConnector.ts
+++ b/src/helpers/walletConnector.ts
@@ -1,0 +1,71 @@
+// handle.me#494 — framework-agnostic CIP-30 wallet connector primitives, shared across
+// handle.me + marketplace.handle.me (React) and merch.handle.me (Lit). Deliberately has NO
+// React/Lit and NO cardano-address dependency: it returns raw CIP-30 values; each app applies
+// its own hex->bech32 conversion + balance decoding (which stays app-specific).
+
+export interface AvailableWallet {
+    key: string;
+    name: string;
+    icon: string;
+}
+
+export interface Cip30WalletStub {
+    icon?: string;
+    name?: string;
+    apiVersion?: string;
+    enable?: () => Promise<Cip30Api>;
+}
+
+export interface Cip30Api {
+    getNetworkId: () => Promise<number>;
+    getChangeAddress: () => Promise<string>;
+    getRewardAddresses: () => Promise<string[]>;
+    getUtxos: () => Promise<string[] | undefined>;
+    getBalance: () => Promise<string>;
+    signTx: (tx: string, partialSign?: boolean) => Promise<string>;
+    submitTx: (tx: string) => Promise<string>;
+}
+
+export interface WalletConnection {
+    walletKey: string;
+    walletIcon: string;
+    networkId: number;
+    /** raw CIP-30 change address (hex CBOR) — convert to bech32 in the consuming app */
+    changeAddressHex: string;
+    /** raw CIP-30 first reward (stake) address (hex CBOR) — convert in the consuming app */
+    rewardAddressHex: string;
+}
+
+type CardanoNamespace = Record<string, Cip30WalletStub> | null | undefined;
+
+// Discover injected CIP-30 wallets from `window.cardano` — entries that expose `enable`.
+export const listAvailableWallets = (cardano: CardanoNamespace): AvailableWallet[] => {
+    if (!cardano) return [];
+    return Object.keys(cardano)
+        .filter((key) => typeof cardano[key]?.enable === 'function')
+        .map((key) => ({ key, name: cardano[key]?.name ?? key, icon: cardano[key]?.icon ?? '' }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+};
+
+// Enable a wallet by key, returning its CIP-30 API. Throws if the wallet isn't injected.
+export const enableWallet = async (cardano: CardanoNamespace, walletKey: string): Promise<Cip30Api> => {
+    const wallet = cardano?.[walletKey];
+    if (typeof wallet?.enable !== 'function') {
+        throw new Error(`Wallet "${walletKey}" is not available`);
+    }
+    return wallet.enable();
+};
+
+// Build the normalized (raw CIP-30) connection payload from an enabled API.
+export const getWalletConnection = async (
+    api: Cip30Api,
+    walletKey: string,
+    walletIcon: string
+): Promise<WalletConnection> => {
+    const [networkId, changeAddressHex, rewardAddresses] = await Promise.all([
+        api.getNetworkId(),
+        api.getChangeAddress(),
+        api.getRewardAddresses()
+    ]);
+    return { walletKey, walletIcon, networkId, changeAddressHex, rewardAddressHex: rewardAddresses[0] ?? '' };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,5 @@ export {
   CustomTooltip,
   FilterDropdown
 };
+
+export * from "./helpers/walletConnector";


### PR DESCRIPTION
Step 1 of handle.me#494. Centralizes the CIP-30 wallet discovery + enable that handle.me / marketplace (React) and merch (Lit) each reimplement. Exports `listAvailableWallets`, `enableWallet`, `getWalletConnection` + types. **No** React/Lit and **no** cardano-address dep — returns raw CIP-30 values; apps keep their own hex→bech32 / balance decode. Compiles standalone (strict); logic verified externally (no test runner in this package).

Once published, the per-app adoption PRs swap the duplicated discovery/enable for this shared module (no UX change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)