### PR TITLE
Add helper coverage tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "rollup-plugin-postcss": "^4.0.2",
         "storybook": "^9.1.20",
         "tailwindcss": "^3.4.19",
+        "tsx": "^4.20.6",
         "typescript": "^5.2.2"
       },
       "peerDependencies": {
@@ -9505,6 +9506,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "rollup-plugin-postcss": "^4.0.2",
     "storybook": "^9.1.20",
     "tailwindcss": "^3.4.19",
+    "tsx": "^4.20.6",
     "typescript": "^5.2.2"
   },
   "peerDependencies": {
@@ -113,14 +114,14 @@
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.0.18",
     "@koralabs/handle-svg": "^3.0.15",
+    "@koralabs/kora-labs-common": "^6.7.4",
     "framer-motion": "^10.16.4",
     "qr-code-styling": "1.5.0",
     "rc-slider": "^10.5.0",
     "react-color": "^2.19.3",
     "react-hook-form": "^7.47.0",
     "react-icons": "^4.11.0",
-    "tinycolor2": "^1.6.0",
-    "@koralabs/kora-labs-common": "^6.7.4"
+    "tinycolor2": "^1.6.0"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006",
@@ -128,7 +129,8 @@
     "build:tsc": "tsc",
     "build": "chmod +x ./build.sh && ./build.sh",
     "lint": "echo \"No linting configured\"",
-    "test": "echo \"No tests configured\""
+    "test": "tsx --test \"test/**/*.test.ts\"",
+    "coverage": "tsx --test --experimental-test-coverage --test-coverage-include=src/helpers/*.ts \"test/**/*.test.ts\""
   },
   "files": [
     "*"

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,4 +1,4 @@
-import { HexString } from "@koralabs/kora-labs-common";
+import type { HexString } from "@koralabs/kora-labs-common";
 
 export const delay = (ms: number): Promise<void> => {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/test/helpers/index.test.ts
+++ b/test/helpers/index.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertIsNode, delay, hexStringToColor, isValidColor } from "../../src/helpers/index.ts";
+
+test("isValidColor accepts six and eight digit hex colors", () => {
+  assert.equal(isValidColor("#A1b2C3"), true);
+  assert.equal(isValidColor("#a1b2c3d4"), true);
+});
+
+test("isValidColor rejects malformed colors", () => {
+  assert.equal(isValidColor("a1b2c3"), false);
+  assert.equal(isValidColor("#12345"), false);
+  assert.equal(isValidColor("#123456789"), false);
+  assert.equal(isValidColor("#12zz56"), false);
+});
+
+test("hexStringToColor converts valid Cardano hex colors", () => {
+  assert.equal(hexStringToColor("0x112233"), "#112233");
+  assert.equal(hexStringToColor("0x11223344"), "#11223344");
+});
+
+test("hexStringToColor falls back for invalid values", () => {
+  assert.equal(hexStringToColor("0x12345"), "#ffffff00");
+  assert.equal(hexStringToColor("not-a-color", "#000000"), "#000000");
+});
+
+test("delay resolves after the requested timeout", async () => {
+  const startedAt = Date.now();
+  await delay(1);
+  assert.ok(Date.now() - startedAt >= 0);
+});
+
+test("assertIsNode accepts node-like event targets", () => {
+  assert.doesNotThrow(() => assertIsNode({ nodeType: 1 } as unknown as EventTarget));
+});
+
+test("assertIsNode rejects null and non-node event targets", () => {
+  assert.throws(() => assertIsNode(null), /Node expected/);
+  assert.throws(() => assertIsNode({} as EventTarget), /Node expected/);
+});

--- a/test/helpers/walletConnector.test.ts
+++ b/test/helpers/walletConnector.test.ts
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  enableWallet,
+  getWalletConnection,
+  listAvailableWallets,
+  type Cip30Api,
+} from "../../src/helpers/walletConnector.ts";
+
+test("listAvailableWallets returns sorted wallets with enable functions", () => {
+  const wallets = listAvailableWallets({
+    nami: { name: "Nami", icon: "nami.svg", enable: async () => ({} as Cip30Api) },
+    lace: { name: "Lace", enable: async () => ({} as Cip30Api) },
+    metadataOnly: { name: "Metadata only" },
+  });
+
+  assert.deepEqual(wallets, [
+    { key: "lace", name: "Lace", icon: "" },
+    { key: "nami", name: "Nami", icon: "nami.svg" },
+  ]);
+});
+
+test("listAvailableWallets handles missing cardano namespace", () => {
+  assert.deepEqual(listAvailableWallets(undefined), []);
+  assert.deepEqual(listAvailableWallets(null), []);
+});
+
+test("enableWallet passes extension options to the selected wallet", async () => {
+  const api = {} as Cip30Api;
+  const options = { extensions: [{ cip: 95 }] };
+  let receivedOptions: unknown;
+
+  const enabled = await enableWallet(
+    {
+      lace: {
+        enable: async (enableOptions) => {
+          receivedOptions = enableOptions;
+          return api;
+        },
+      },
+    },
+    "lace",
+    options
+  );
+
+  assert.equal(enabled, api);
+  assert.equal(receivedOptions, options);
+});
+
+test("enableWallet rejects unavailable wallets", async () => {
+  await assert.rejects(() => enableWallet({}, "missing"), /Wallet "missing" is not available/);
+  await assert.rejects(
+    () => enableWallet({ metadataOnly: { name: "Metadata only" } }, "metadataOnly"),
+    /Wallet "metadataOnly" is not available/
+  );
+});
+
+test("getWalletConnection builds the raw CIP-30 connection payload", async () => {
+  const api: Cip30Api = {
+    getNetworkId: async () => 1,
+    getChangeAddress: async () => "change-address-hex",
+    getRewardAddresses: async () => ["reward-address-hex"],
+    getUtxos: async () => [],
+    getBalance: async () => "0",
+    signTx: async (tx) => tx,
+    submitTx: async (tx) => tx,
+  };
+
+  assert.deepEqual(await getWalletConnection(api, "lace", "lace.svg"), {
+    walletKey: "lace",
+    walletIcon: "lace.svg",
+    networkId: 1,
+    changeAddressHex: "change-address-hex",
+    rewardAddressHex: "reward-address-hex",
+  });
+});
+
+test("getWalletConnection falls back to an empty reward address", async () => {
+  const api: Cip30Api = {
+    getNetworkId: async () => 0,
+    getChangeAddress: async () => "change-address-hex",
+    getRewardAddresses: async () => [],
+    getUtxos: async () => undefined,
+    getBalance: async () => "0",
+    signTx: async (tx) => tx,
+    submitTx: async (tx) => tx,
+  };
+
+  assert.equal((await getWalletConnection(api, "nami", "")).rewardAddressHex, "");
+});


### PR DESCRIPTION
Adds Node test coverage for helper utilities and CIP-30 wallet connector primitives, wires npm test to run the suite, and adds a coverage script focused on helpers.

Verify: npm test passed (13 tests).